### PR TITLE
Harden wiki file reads against symlink and large-file DoS

### DIFF
--- a/internal/wiki/answer.go
+++ b/internal/wiki/answer.go
@@ -3,7 +3,6 @@ package wiki
 import (
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -28,16 +27,12 @@ func SearchWiki(wikiDir string, terms []string) ([]string, error) {
 		if !strings.EqualFold(filepath.Ext(d.Name()), ".md") {
 			return nil
 		}
-		info, serr := d.Info()
-		if serr != nil {
-			return serr
-		}
-		if info.Size() > maxFileBytes {
-			return fmt.Errorf("%s: file too large (%d bytes, max %d)", path, info.Size(), maxFileBytes)
-		}
-		data, rerr := os.ReadFile(path)
+		data, ok, rerr := readRegularFileLimited(path, maxFileBytes)
 		if rerr != nil {
 			return rerr
+		}
+		if !ok {
+			return nil
 		}
 		lower := strings.ToLower(string(data))
 		for _, term := range terms {

--- a/internal/wiki/answer_test.go
+++ b/internal/wiki/answer_test.go
@@ -49,6 +49,25 @@ func TestSearchWiki_TooLarge(t *testing.T) {
 	}
 }
 
+func TestSearchWiki_SkipsSymlinkedMarkdownFile(t *testing.T) {
+	dir := t.TempDir()
+	external := filepath.Join(t.TempDir(), "outside.md")
+	if err := os.WriteFile(external, []byte("# Outside\n\nfox\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(dir, "linked.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := SearchWiki(dir, []string{"fox"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %v, want no matches", got)
+	}
+}
+
 func TestSearchWiki(t *testing.T) {
 	dir := t.TempDir()
 	files := map[string]string{

--- a/internal/wiki/ingest.go
+++ b/internal/wiki/ingest.go
@@ -6,6 +6,7 @@ package wiki
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -51,14 +52,53 @@ func ListRawFiles(rawDir string) ([]string, error) {
 
 // ReadRawFile returns the contents of a raw source file. It is read-only.
 func ReadRawFile(path string) ([]byte, error) {
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	if err != nil {
 		return nil, err
 	}
-	if info.Size() > maxFileBytes {
-		return nil, fmt.Errorf("%s: file too large (%d bytes, max %d)", path, info.Size(), maxFileBytes)
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("%s: symlink not allowed", path)
 	}
-	return os.ReadFile(path)
+	data, ok, err := readRegularFileLimited(path, maxFileBytes)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("%s: not a regular file", path)
+	}
+	return data, nil
+}
+
+func readRegularFileLimited(path string, maxBytes int64) ([]byte, bool, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, false, nil
+	}
+	if !info.Mode().IsRegular() {
+		return nil, false, nil
+	}
+	if info.Size() > maxBytes {
+		return nil, false, fmt.Errorf("%s: file too large (%d bytes, max %d)", path, info.Size(), maxBytes)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, false, err
+	}
+	defer f.Close()
+
+	limited := io.LimitReader(f, maxBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, false, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, false, fmt.Errorf("%s: file too large (over %d bytes)", path, maxBytes)
+	}
+	return data, true, nil
 }
 
 // SourcePageTemplate produces a bootstrap wiki page body for an ingested

--- a/internal/wiki/ingest_test.go
+++ b/internal/wiki/ingest_test.go
@@ -78,6 +78,24 @@ func TestReadRawFile_TooLarge(t *testing.T) {
 	}
 }
 
+func TestReadRawFile_Symlink(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "target.txt")
+	if err := os.WriteFile(target, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(t.TempDir(), "linked.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ReadRawFile(link)
+	if err == nil {
+		t.Fatal("expected error for symlink")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestSourcePageTemplate(t *testing.T) {
 	got := SourcePageTemplate("Example Source", "raw/example.txt")
 	musts := []string{

--- a/internal/wikilint/report.go
+++ b/internal/wikilint/report.go
@@ -2,6 +2,7 @@ package wikilint
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -126,16 +127,12 @@ func loadPages(wikiDir string) (map[string]*Page, error) {
 		if !strings.EqualFold(filepath.Ext(d.Name()), ".md") {
 			return nil
 		}
-		info, serr := d.Info()
-		if serr != nil {
-			return serr
-		}
-		if info.Size() > maxPageBytes {
-			return fmt.Errorf("%s: file too large (%d bytes, max %d)", path, info.Size(), maxPageBytes)
-		}
-		data, rerr := os.ReadFile(path)
+		data, ok, rerr := readRegularFileLimited(path, maxPageBytes)
 		if rerr != nil {
 			return rerr
+		}
+		if !ok {
+			return nil
 		}
 		rel, rerr := filepath.Rel(resolved, path)
 		if rerr != nil {
@@ -150,6 +147,38 @@ func loadPages(wikiDir string) (map[string]*Page, error) {
 		return nil, err
 	}
 	return pages, nil
+}
+
+func readRegularFileLimited(path string, maxBytes int64) ([]byte, bool, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, false, nil
+	}
+	if !info.Mode().IsRegular() {
+		return nil, false, nil
+	}
+	if info.Size() > maxBytes {
+		return nil, false, fmt.Errorf("%s: file too large (%d bytes, max %d)", path, info.Size(), maxBytes)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, false, err
+	}
+	defer f.Close()
+
+	limited := io.LimitReader(f, maxBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, false, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, false, fmt.Errorf("%s: file too large (over %d bytes)", path, maxBytes)
+	}
+	return data, true, nil
 }
 
 func sortedPageKeys(pages map[string]*Page) []string {

--- a/internal/wikilint/report_io_test.go
+++ b/internal/wikilint/report_io_test.go
@@ -1,0 +1,29 @@
+package wikilint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLint_SkipsSymlinkedMarkdownFile(t *testing.T) {
+	wikiDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(wikiDir, "index.md"), []byte("# Index\n\n## Sources\n\n- test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside.md")
+	if err := os.WriteFile(outside, []byte("## no heading\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(wikiDir, "linked.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := Lint(wikiDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.OK() {
+		t.Fatalf("unexpected issues: %#v", report.Issues)
+	}
+}


### PR DESCRIPTION
### Motivation
- Several helpers (`loadPages`, `SearchWiki`, and `ReadRawFile`) used `os.ReadFile` unconditionally which allowed unbounded reads and could be abused by oversized files or symlinks to special devices causing OOM or hangs in CI.  
- The goal is to prevent denial-of-service when processing untrusted content by skipping non-regular/symlinked files and capping per-file reads.

### Description
- Add bounded, regular-file-aware reading via `readRegularFileLimited` that uses `os.Lstat` to detect symlinks and non-regular files, checks `Size()` against a `max*Bytes` constant, and reads through `io.LimitReader` to cap bytes actually read.  
- Update `internal/wikilint/loadPages` to use the bounded reader and skip symlinked or non-regular markdown files instead of calling `os.ReadFile`.  
- Update `internal/wiki/SearchWiki` to use the same bounded reader and skip unsafe files when walking the wiki.  
- Update `internal/wiki/ReadRawFile` to explicitly reject symlinks and non-regular files and to return bounded content via the helper.  
- Add regression tests covering symlink handling and large-file rejection: `TestLint_SkipsSymlinkedMarkdownFile`, `TestSearchWiki_SkipsSymlinkedMarkdownFile`, and `TestReadRawFile_Symlink`.

### Testing
- Reformatted with `gofmt` and ran static checks with `go vet ./...` which passed.  
- Ran unit tests with `go test ./...` and all package tests passed including the new symlink/size regression tests.  
- Ran repository verification via `make setup` followed by `make check` (which runs `gofmt -l .`, `go vet ./...`, `go test ./...`, and `go run ./cmd/wikilint -wiki ./wiki`) and `wikilint` reported `wikilint: OK` meaning the full check passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df1051c31c83218edc45e93ddd886c)