### PR TITLE
Do not resolve wiki root symlink in wikilint to avoid escaping repo boundary

### DIFF
--- a/internal/wikilint/report.go
+++ b/internal/wikilint/report.go
@@ -110,13 +110,8 @@ func Lint(wikiDir string) (*Report, error) {
 // loadPages walks wikiDir and parses all .md files into Page values keyed by
 // their wiki-root-relative slash-separated path (e.g. "entities/foo.md").
 func loadPages(wikiDir string) (map[string]*Page, error) {
-	// Resolve symlinks so WalkDir descends into the real directory.
-	resolved, err := filepath.EvalSymlinks(wikiDir)
-	if err != nil {
-		return nil, fmt.Errorf("resolve wiki dir: %w", err)
-	}
 	pages := map[string]*Page{}
-	err = filepath.WalkDir(resolved, func(path string, d fs.DirEntry, err error) error {
+	err := filepath.WalkDir(wikiDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -137,7 +132,7 @@ func loadPages(wikiDir string) (map[string]*Page, error) {
 		if rerr != nil {
 			return rerr
 		}
-		rel, rerr := filepath.Rel(resolved, path)
+		rel, rerr := filepath.Rel(wikiDir, path)
 		if rerr != nil {
 			return rerr
 		}

--- a/internal/wikilint/report_test.go
+++ b/internal/wikilint/report_test.go
@@ -1,0 +1,34 @@
+package wikilint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadPages_DoesNotFollowRootSymlink(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	outside := filepath.Join(tmp, "outside")
+	if err := os.Mkdir(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	outsidePage := filepath.Join(outside, "outside.md")
+	if err := os.WriteFile(outsidePage, []byte("# outside\n\n## Summary\n"), 0o644); err != nil {
+		t.Fatalf("write outside page: %v", err)
+	}
+
+	wikiLink := filepath.Join(tmp, "wiki")
+	if err := os.Symlink(outside, wikiLink); err != nil {
+		t.Fatalf("symlink wiki: %v", err)
+	}
+
+	pages, err := loadPages(wikiLink)
+	if err != nil {
+		t.Fatalf("loadPages: %v", err)
+	}
+	if len(pages) != 0 {
+		t.Fatalf("got %d pages, want 0", len(pages))
+	}
+}


### PR DESCRIPTION
### Motivation
- Resolving the configured `wiki/` path with `filepath.EvalSymlinks` let a malicious symlink point the wiki root at an external location and caused `wikilint` to traverse and read Markdown files outside the repository.
- The change closes this local filesystem traversal/DoS/information exposure vector by ensuring linting only walks the configured path rather than the symlink target.

### Description
- Removed the call to `filepath.EvalSymlinks` in `loadPages` and changed `filepath.WalkDir` to walk the provided `wikiDir` directly.
- Kept relative path computation rooted at the configured `wikiDir` (changed `filepath.Rel(resolved, path)` to `filepath.Rel(wikiDir, path)`).
- Added `internal/wikilint/report_test.go` with `TestLoadPages_DoesNotFollowRootSymlink` that creates a `wiki` symlink to an outside directory and asserts `loadPages` does not ingest files from that target.

### Testing
- Ran `make setup && make check`, which runs `gofmt`, `go vet ./...`, `go test ./...`, and `go run ./cmd/wikilint -wiki ./wiki`, and the command completed successfully.
- Unit tests (`go test ./...`) passed for the `internal/wikilint` package including the new regression test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df104fa21883218dc3d1603b39f666)